### PR TITLE
pass key_is_down function call to p5js

### DIFF
--- a/src/proceso/binding.py
+++ b/src/proceso/binding.py
@@ -31,7 +31,6 @@ class BaseSketch(Constants, SystemVariables):
         key_pressed: Callable | None = None,
         key_released: Callable | None = None,
         key_typed: Callable | None = None,
-        key_is_down: Callable | None = None,
         mouse_moved: Callable | None = None,
         mouse_dragged: Callable | None = None,
         mouse_pressed: Callable | None = None,
@@ -42,7 +41,7 @@ class BaseSketch(Constants, SystemVariables):
         request_pointer_lock: Callable | None = None,
         exit_pointer_lock: Callable | None = None,
     ):
-        """"Runs a sketch in active mode."""
+        """Runs a sketch in active mode."""
         import inspect
         from pyodide.ffi import create_proxy
 
@@ -79,8 +78,6 @@ class BaseSketch(Constants, SystemVariables):
             self._p5js.keyReleased = wrap_event_func(key_released)
         if callable(key_typed):
             self._p5js.keyTyped = wrap_event_func(key_typed)
-        if callable(key_is_down):
-            self._p5js.keyIsDown = create_proxy(key_is_down)
         if callable(mouse_moved):
             self._p5js.mouseMoved = wrap_event_func(mouse_moved)
         if callable(mouse_dragged):

--- a/src/proceso/events.py
+++ b/src/proceso/events.py
@@ -38,3 +38,16 @@ class Events(BaseSketch):
         pointerLock for example to make ui elements usable etc.
         """
         self._p5js.exitPointerLock()
+
+    # =====
+    # Keyboard
+    # =====
+    def key_is_down(self, code: int) -> bool:
+        """The key_is_down() function checks if the key is currently down, i.e.
+        pressed. It can be used if you have an object that moves, and you want
+        several keys to be able to affect its behaviour simultaneously, such as
+        moving a sprite diagonally. You can put in any number representing the
+        keyCode of the key, or use any of the variable keyCode names listed here
+        http://p5js.org/reference/#p5/keyCode.
+        """
+        return self._p5js.keyIsDown(code)


### PR DESCRIPTION
Rather than using it as an event handler. Fixes #8

See issue #8 for more details.