### PR TITLE
Add quotes when passing a string argument to text_font()

### DIFF
--- a/src/proceso/typography.py
+++ b/src/proceso/typography.py
@@ -136,4 +136,7 @@ class Typography(BaseSketch):
 
         WEBGL: Only fonts loaded via load_font() are supported.
         """
-        self._p5js.textFont(font, size)
+        if type(font) == str:
+            self._p5js.textFont(f'"{font}"', size)
+        else:
+            self._p5js.textFont(font, size)


### PR DESCRIPTION
Fonts with spaces in their names must be quoted or they will not work in a sketch.